### PR TITLE
Remove KeycloakServerProperties hack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,26 +41,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
             <version>${resteasy.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.2.RELEASE</version>
+        <version>1.5.3.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -23,7 +23,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <keycloak.version>3.0.0.Final</keycloak.version>
+        <keycloak.version>3.1.0.Final</keycloak.version>
         <resteasy.version>3.0.16.Final</resteasy.version>
         <infinispan.version>8.1.0.Final</infinispan.version>
     </properties>

--- a/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApp.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApp.java
@@ -24,9 +24,8 @@ public class EmbeddedKeycloakApp {
 
             Integer port = serverProperties.getPort();
             String rootContextPath = serverProperties.getContextPath();
-            String keycloakContextPath = keycloakServerProperties.getContextPath();
 
-            System.out.printf("Embedded Keycloak started: http://localhost:%s%s%s to use keycloak%n", port, rootContextPath, keycloakContextPath);
+            System.out.printf("Embedded Keycloak started: http://localhost:%s%s to use keycloak%n", port, rootContextPath);
         };
     }
 }

--- a/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApplication.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApplication.java
@@ -53,10 +53,6 @@ public class EmbeddedKeycloakApplication extends KeycloakApplication {
 
     InvocationHandler invocationHandler = (proxy, method, args) -> {
 
-      if ("getContextPath".equals(method.getName())) {
-        return keycloakServerProperties.getContextPath();
-      }
-
       if ("getInitParameter".equals(method.getName()) && args.length == 1 && "keycloak.embedded".equals(args[0])) {
         return "true";
       }

--- a/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApplication.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApplication.java
@@ -18,8 +18,7 @@ public class EmbeddedKeycloakApplication extends KeycloakApplication {
   static KeycloakServerProperties keycloakServerProperties;
 
   public EmbeddedKeycloakApplication(@Context ServletContext context, @Context Dispatcher dispatcher) {
-
-    super(augmentToRedirectContextPath(context), dispatcher);
+    super(context, dispatcher);
 
     tryCreateMasterRealmAdminUser();
   }
@@ -45,21 +44,4 @@ public class EmbeddedKeycloakApplication extends KeycloakApplication {
     session.close();
   }
 
-
-  static ServletContext augmentToRedirectContextPath(ServletContext servletContext) {
-
-    ClassLoader classLoader = servletContext.getClassLoader();
-    Class[] interfaces = {ServletContext.class};
-
-    InvocationHandler invocationHandler = (proxy, method, args) -> {
-
-      if ("getInitParameter".equals(method.getName()) && args.length == 1 && "keycloak.embedded".equals(args[0])) {
-        return "true";
-      }
-
-      return method.invoke(servletContext, args);
-    };
-
-    return ServletContext.class.cast(Proxy.newProxyInstance(classLoader, interfaces, invocationHandler));
-  }
 }

--- a/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApplication.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApplication.java
@@ -4,6 +4,8 @@ import org.jboss.resteasy.core.Dispatcher;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.services.resources.KeycloakApplication;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.Context;
@@ -15,10 +17,13 @@ import java.lang.reflect.Proxy;
  */
 public class EmbeddedKeycloakApplication extends KeycloakApplication {
 
-  static KeycloakServerProperties keycloakServerProperties;
+  private KeycloakServerProperties keycloakServerProperties;
 
   public EmbeddedKeycloakApplication(@Context ServletContext context, @Context Dispatcher dispatcher) {
     super(context, dispatcher);
+
+    WebApplicationContext webCtx = WebApplicationContextUtils.getWebApplicationContext(context);
+    this.keycloakServerProperties = webCtx.getBean(KeycloakServerProperties.class);
 
     tryCreateMasterRealmAdminUser();
   }

--- a/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakConfig.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakConfig.java
@@ -4,7 +4,6 @@ import org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.keycloak.services.filters.KeycloakSessionServletFilter;
 import org.keycloak.services.listeners.KeycloakSessionDestroyListener;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
@@ -22,9 +21,9 @@ class EmbeddedKeycloakConfig {
 
         ServletRegistrationBean servlet = new ServletRegistrationBean(new HttpServlet30Dispatcher());
         servlet.addInitParameter("javax.ws.rs.Application", EmbeddedKeycloakApplication.class.getName());
-        servlet.addInitParameter(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX, keycloakServerProperties.getContextPath());
+        servlet.addInitParameter(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX, "/");
         servlet.addInitParameter(ResteasyContextParameters.RESTEASY_USE_CONTAINER_FORM_PARAMS, "true");
-        servlet.addUrlMappings(keycloakServerProperties.getContextPath() + "/*");
+        servlet.addUrlMappings("/*");
         servlet.setLoadOnStartup(1);
         servlet.setAsyncSupported(true);
 
@@ -42,7 +41,7 @@ class EmbeddedKeycloakConfig {
         FilterRegistrationBean filter = new FilterRegistrationBean();
         filter.setName("Keycloak Session Management");
         filter.setFilter(new KeycloakSessionServletFilter());
-        filter.addUrlPatterns(keycloakServerProperties.getContextPath() + "/*");
+        filter.addUrlPatterns("/*");
 
         return filter;
     }

--- a/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakConfig.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakConfig.java
@@ -15,10 +15,6 @@ class EmbeddedKeycloakConfig {
 
     @Bean
     ServletRegistrationBean keycloakJaxRsApplication(KeycloakServerProperties keycloakServerProperties) {
-
-        //FIXME: hack to propagate Spring Boot Properties to Keycloak Application
-        EmbeddedKeycloakApplication.keycloakServerProperties = keycloakServerProperties;
-
         ServletRegistrationBean servlet = new ServletRegistrationBean(new HttpServlet30Dispatcher());
         servlet.addInitParameter("keycloak.embedded", "true");
         servlet.addInitParameter("javax.ws.rs.Application", EmbeddedKeycloakApplication.class.getName());

--- a/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakConfig.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakConfig.java
@@ -20,6 +20,7 @@ class EmbeddedKeycloakConfig {
         EmbeddedKeycloakApplication.keycloakServerProperties = keycloakServerProperties;
 
         ServletRegistrationBean servlet = new ServletRegistrationBean(new HttpServlet30Dispatcher());
+        servlet.addInitParameter("keycloak.embedded", "true");
         servlet.addInitParameter("javax.ws.rs.Application", EmbeddedKeycloakApplication.class.getName());
         servlet.addInitParameter(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX, "/");
         servlet.addInitParameter(ResteasyContextParameters.RESTEASY_USE_CONTAINER_FORM_PARAMS, "true");

--- a/src/main/java/de/tdlabs/examples/keycloak/KeycloakServerProperties.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/KeycloakServerProperties.java
@@ -8,19 +8,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "keycloak")
 public class KeycloakServerProperties {
 
-    String contextPath = "/auth";
-
     String adminUsername = "admin";
 
     String adminPassword = "admin";
-
-    public String getContextPath() {
-        return contextPath;
-    }
-
-    public void setContextPath(String contextPath) {
-        this.contextPath = contextPath;
-    }
 
     public String getAdminUsername() {
         return adminUsername;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  context-path: /
+  context-path: /auth
   port: 8080
 
 resteasy:
@@ -12,9 +12,6 @@ management:
   security:
     enabled: true
     roles: MANAGER
-
-keycloak:
-  contextPath: /auth
 
 security:
   user:


### PR DESCRIPTION
Hi there - thank you for this proof of concept. I was looking for something similar, even started experimenting with Jetty embdeed, but this approach is much leaner. 

This set of PRs (apart from updating versions) are about removing proxy on the ServletContext and passing static reference to KeycloakServerProperties

* ServletContext
  * Sets up contextPath globally for springboot - removes a need for proxing ServletContext
  * keycloak.embedded can be set and servlet initialization parameter
* KeycloakServerProperties
  * I'm taking the bean directly from Spring context with `WebApplicationContextUtils#getWebApplicationContext` method - designed to reference Spring context in servlet environment.

Hope I haven't missed anything in testing - but works for my example applications.