### PR TITLE
Ability to import existing keycloak configuration

### DIFF
--- a/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApplication.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/EmbeddedKeycloakApplication.java
@@ -1,14 +1,20 @@
 package de.tdlabs.examples.keycloak;
 
 import org.jboss.resteasy.core.Dispatcher;
+import org.keycloak.exportimport.ExportImportConfig;
+import org.keycloak.exportimport.ExportImportManager;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.services.resources.KeycloakApplication;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.Context;
+import java.io.File;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
  * Created by tom on 12.06.16.
@@ -18,10 +24,10 @@ public class EmbeddedKeycloakApplication extends KeycloakApplication {
   static KeycloakServerProperties keycloakServerProperties;
 
   public EmbeddedKeycloakApplication(@Context ServletContext context, @Context Dispatcher dispatcher) {
-
     super(augmentToRedirectContextPath(context), dispatcher);
 
     tryCreateMasterRealmAdminUser();
+    tryImportExistingKeycloakFile();
   }
 
   private void tryCreateMasterRealmAdminUser() {
@@ -45,6 +51,21 @@ public class EmbeddedKeycloakApplication extends KeycloakApplication {
     session.close();
   }
 
+  private void tryImportExistingKeycloakFile() {
+    KeycloakSession session = getSessionFactory().create();
+
+    URL url = getClass().getResource(keycloakServerProperties.getUsersConfigurationFile());
+    if (url != null && new File(url.getPath()).exists()) {
+      ExportImportConfig.setAction("import");
+      ExportImportConfig.setProvider("singleFile");
+      ExportImportConfig.setFile(url.getPath());
+
+      ExportImportManager manager = new ExportImportManager(session);
+      manager.runImport();
+    }
+
+    session.close();
+  }
 
   static ServletContext augmentToRedirectContextPath(ServletContext servletContext) {
 

--- a/src/main/java/de/tdlabs/examples/keycloak/KeycloakServerProperties.java
+++ b/src/main/java/de/tdlabs/examples/keycloak/KeycloakServerProperties.java
@@ -14,6 +14,8 @@ public class KeycloakServerProperties {
 
     String adminPassword = "admin";
 
+    String usersConfigurationFile = "/keycloak-users-config.json";
+
     public String getContextPath() {
         return contextPath;
     }
@@ -36,5 +38,13 @@ public class KeycloakServerProperties {
 
     public void setAdminPassword(String adminPassword) {
         this.adminPassword = adminPassword;
+    }
+
+    public String getUsersConfigurationFile() {
+        return usersConfigurationFile;
+    }
+
+    public void setUsersConfigurationFile(String usersConfigurationFile) {
+        this.usersConfigurationFile = usersConfigurationFile;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ management:
 
 keycloak:
   contextPath: /auth
+  usersConfigurationFile: /keycloak-users.json
 
 security:
   user:


### PR DESCRIPTION
In my scenario I have exported keycloak configuration (single file) with I wanted to import on startup. While Keycloak allows different scenarios for importing configuration JSON, I think in proof of concept / testing scenarios importing a single file is most common scenario.