### PR TITLE
Upgrade example to Spring Boot 2.1.6.RELEASE and Keycloak 6.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.3.RELEASE</version>
+        <version>2.1.6.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -23,9 +23,9 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <keycloak.version>5.0.0</keycloak.version>
-        <resteasy.version>3.6.2.Final</resteasy.version>
-        <infinispan.version>9.4.3.Final</infinispan.version>
+        <keycloak.version>6.0.1</keycloak.version>
+        <resteasy.version>3.6.3.Final</resteasy.version>
+        <infinispan.version>9.4.8.Final</infinispan.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Upgrade example to spring Boot 2.1.6.RELEASE and Keycloak 6.0.1.
Also I updated the version of Infinispan and RESTEasy referring to the following:

* infinispan.version: https://github.com/keycloak/keycloak/blob/6.0.1/pom.xml#L71
* resteasy.version: https://github.com/keycloak/keycloak/blob/6.0.1/pom.xml#L82
